### PR TITLE
 Do not close menu if uses clicks on scrollbar. edit to menu.js is a …

### DIFF
--- a/lib/ext/menu.js
+++ b/lib/ext/menu.js
@@ -181,6 +181,10 @@ window.jQuery = window.jQuery || window.shoestring;
 
 		// close on any click, even on the menu
 		$( document ).bind( "mouseup", function(){
+			//if an autocomplete menu, and user clicks in scrollbar, don't close
+			if(self.element.classList[0] =="suggest" && $(self.element).find(".menu-selected").length == 0 && $(event.target).selector.tagName =="OL"){
+				return false;
+			}
 			self.close();
 		} );
 

--- a/src/core.js
+++ b/src/core.js
@@ -80,7 +80,10 @@
   };
 
   AutoComplete.prototype.select = function() {
-    this.val( this.strip(this.menu.selectActive() || "") );
+    var selectedCount =$(this.menu.element).find(".menu-selected").length;
+    if(selectedCount){//only close menu if a selection was made (clicks on scrollbar should not close menu)
+      this.val( this.strip(this.menu.selectActive() || "") );
+    }
   };
 
   AutoComplete.prototype.compareDataItem = function(item, val){


### PR DESCRIPTION
…hack. menu.prototype.init should be overriden within core.

 filamentgroup/auto-complete#12
