### PR TITLE
prevent close on scrollbar mouseup

### DIFF
--- a/lib/ext/menu.js
+++ b/lib/ext/menu.js
@@ -180,9 +180,11 @@ window.jQuery = window.jQuery || window.shoestring;
 		var self = this;
 
 		// close on any click, even on the menu
-		$( document ).bind( "mouseup", function(){
+		// NOTE we can't close on `mouseup` in case there's overflow scrolling
+		// because the `mouseup` event is fired when using the scrollbar
+		$( document ).bind( "click", function(){
 			self.close();
-		} );
+		});
 
 		this._bindKeyHandling();
 

--- a/lib/ext/menu.js
+++ b/lib/ext/menu.js
@@ -175,11 +175,11 @@ window.jQuery = window.jQuery || window.shoestring;
 		this.close();
 		var self = this;
 
-		// close on any click, even on the menu
-		// NOTE we can't close on `mouseup` in case there's overflow scrolling
-		// because the `mouseup` event is fired when using the scrollbar
-		$( document ).bind( "mouseup", function(){
-			self.close();
+		$( document ).bind( "mouseup", function(event){
+			// only close the menu if the click is outside the menu element
+			if( ! $(event.target).closest( self.$element[0] ).length ){
+				self.close();
+			}
 		});
 
 		this._bindKeyHandling();

--- a/lib/ext/menu.js
+++ b/lib/ext/menu.js
@@ -1,10 +1,6 @@
-/*
- * menu plugin
- *
- * Copyright (c) 2013 Filament Group, Inc.
- * Licensed under MIT
- */
-
+/*! Menu - v0.1.3 - 2016-10-19
+* https://github.com/filamentgroup/menu
+* Copyright (c) 2016 Scott Jehl; Licensed MIT */
 window.jQuery = window.jQuery || window.shoestring;
 
 (function( $, w ) {
@@ -182,7 +178,7 @@ window.jQuery = window.jQuery || window.shoestring;
 		// close on any click, even on the menu
 		// NOTE we can't close on `mouseup` in case there's overflow scrolling
 		// because the `mouseup` event is fired when using the scrollbar
-		$( document ).bind( "click", function(){
+		$( document ).bind( "mouseup", function(){
 			self.close();
 		});
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "grunt test --verbose"
   },
   "dependencies": {
-    "fg-menu": "^0.1.2"
+    "fg-menu": "filamentgroup/Menu#auto-complete-12"
   },
   "devDependencies": {
     "grunt-cli": "~0.1",

--- a/src/init.js
+++ b/src/init.js
@@ -39,7 +39,11 @@
       $this.on( "keyup", $.proxy(autocomplete.suggest, autocomplete) );
       $this.on( "keydown", $.proxy(autocomplete.navigate, autocomplete) );
       $this.on( "blur", $.proxy(autocomplete.blur, autocomplete) );
-      menu.$element.on( "mouseup", $.proxy(autocomplete.select, autocomplete) );
+
+      // NOTE we can't close on `mouseup` in case there's overflow scrolling
+      // because the `mouseup` event is fired when using the scrollbar
+      menu.$element.on( "click", $.proxy(autocomplete.select, autocomplete) );
+
       menu.init();
     });
   };


### PR DESCRIPTION
The `mouseup` binding closes the menu even when a scrollbar is being used.

Fixes #12 

**NOTE** please don't merge this until the menu pull request (https://github.com/filamentgroup/Menu/pull/10) is merged and published to NPM. Then the version can be updated.
